### PR TITLE
Allow argument entry during completing read

### DIFF
--- a/dmenu.el
+++ b/dmenu.el
@@ -97,7 +97,12 @@ Must be set before initializing Dmenu."
            (setq dmenu--history-list nil))
           ((> (length dmenu--history-list) dmenu-history-size)
            (setcdr (nthcdr (- dmenu-history-size 1) dmenu--history-list) nil)))
-    (switch-to-buffer (apply #'make-comint execute-file execute-file nil args))
+    (switch-to-buffer
+      (let* ((cmdlist (split-string-and-unquote execute-file))
+             (name execute-file)
+             (program (car cmdlist))
+             (switches (append (cdr cmdlist) args)))
+        (apply #'make-comint name program nil switches)))
     (set-process-sentinel (get-buffer-process (current-buffer))
                           (lambda (process event)
                             (when (eq 'exit (process-status process))


### PR DESCRIPTION
This change allows the user to enter arguments during the completing read (before pressing ENTER).  This mimics the behavior of dmenu (the suckless program).

Note that this also is a backward-compatible change -- users can continue to enter arguments via the existing method: prefix invocation. Also, if they choose, users can combine the two argument entry methods, and in this case, the `prefix` arguments (in `arg`) will simply be appended to any arguments entered via this new method (i.e., entered during the completing read).