### PR TITLE
fix issue #7

### DIFF
--- a/dmenu.el
+++ b/dmenu.el
@@ -140,12 +140,17 @@ Must be set before initializing Dmenu."
 
 
 (defun dmenu--cache-executable-files()
-  "cache executable files"
-  (let* ((valid-exec-path (seq-uniq (cl-remove-if-not #'file-exists-p (cl-remove-if-not #'stringp exec-path))))
-         (files (cl-mapcan (lambda (dir)
-                             (directory-files dir t nil nil)) valid-exec-path))
-         (executable-files (mapcar #'file-name-nondirectory (cl-remove-if #'file-directory-p (cl-remove-if-not #'file-executable-p files)))))
-    (setq dmenu--cache-executable-files (sort executable-files #'string<))))
+  "Scan $PATH (i.e., `exec-path') for names of executable files and cache them into memory (in variable `dmenu--cache-executable-files')."
+  (let* ((valid-exec-path (seq-uniq
+                           (cl-remove-if-not #'file-exists-p
+                                             (cl-remove-if-not #'stringp exec-path))))
+         (files (cl-mapcan (lambda (dir) (directory-files dir t nil nil))
+                           valid-exec-path))
+         (executable-files (mapcar #'file-name-nondirectory
+                                   (cl-remove-if #'file-directory-p
+                                                 (cl-remove-if-not #'file-executable-p
+                                                                   files)))))
+    (setq dmenu--cache-executable-files (seq-uniq (sort executable-files #'string<)))))
 
 (defvar dmenu--update-timer nil)
 


### PR DESCRIPTION
During the completing read of `M-x dmenu`, when a user uniquely matches an executable filename, but that filename occurs more than once on `$PATH` (`exec-path`), the completing read will show more than one entry with the same (completed) value.  This is because the candidate list `dmenu--cache-executable-files` doesn't have unique entries.  This fix ensures that the candidate list has unique entries.

@lujun9972 The essential fix was just adding a call to `seq-uniq`.  I also want to make sure that the other changes:

- changing the doc string, and
- whitespace addition

are OK by you.  If not, please change anything. Thanks! Rick