### PR TITLE
Don't recycle incomplete command entries

### DIFF
--- a/dmenu.el
+++ b/dmenu.el
@@ -81,18 +81,22 @@ Must be set before initializing Dmenu."
   (let* ((completing-read-fn (if ido-mode
                                  #'ido-completing-read
                                #'completing-read))
-         (execute-file (funcall completing-read-fn dmenu-prompt-string
-                                        (append dmenu--history-list
-                                                (cl-remove-if (lambda (x)
-                                                                (member x dmenu--history-list))
-                                                              dmenu--cache-executable-files))
-                                        nil
-                                        'confirm
-                                        nil
-                                        'dmenu--history-list))
+         (execute-file (funcall completing-read-fn
+                                dmenu-prompt-string
+                                (append dmenu--history-list
+                                        dmenu--cache-executable-files)
+                                nil
+                                'confirm
+                                nil))
          (args (when (= prefix 4)
                  (split-string-and-unquote (read-string "please input the parameters: ")))))
-    (setq dmenu--history-list (cons execute-file (remove execute-file dmenu--history-list)))
+    ;; Add history entries when the user input was a PATH command followed by
+    ;; one or more arguments.
+    (if (let ((cmd+args (split-string execute-file)))
+          (and (> (length cmd+args) 1)
+               (member (car cmd+args) dmenu--cache-executable-files)))
+        (push execute-file dmenu--history-list))
+    ;; Now, limit the size/length of history to `dmenu-history-size' entries.
     (cond ((< dmenu-history-size 1)
            (setq dmenu--history-list nil))
           ((> (length dmenu--history-list) dmenu-history-size)

--- a/dmenu.el
+++ b/dmenu.el
@@ -91,7 +91,7 @@ Must be set before initializing Dmenu."
                                         nil))
          (args (when (= prefix 4)
                  (split-string-and-unquote (read-string "please input the parameters: ")))))
-    (pushnew execute-file dmenu--history-list :test #'string-equal)
+    (setq dmenu--history-list (cons execute-file (remove execute-file dmenu--history-list)))
     (cond ((< dmenu-history-size 1)
            (setq dmenu--history-list nil))
           ((> (length dmenu--history-list) dmenu-history-size)

--- a/dmenu.el
+++ b/dmenu.el
@@ -91,7 +91,9 @@ Must be set before initializing Dmenu."
                                         nil))
          (args (when (= prefix 4)
                  (split-string-and-unquote (read-string "please input the parameters: ")))))
-    (setq dmenu--history-list (cons execute-file (remove execute-file dmenu--history-list)))
+    (if (member (car (split-string execute-file)) dmenu--cache-executable-files)
+        (setq dmenu--history-list (cons execute-file
+                                        (remove execute-file dmenu--history-list))))
     (cond ((< dmenu-history-size 1)
            (setq dmenu--history-list nil))
           ((> (length dmenu--history-list) dmenu-history-size)

--- a/dmenu.el
+++ b/dmenu.el
@@ -81,22 +81,17 @@ Must be set before initializing Dmenu."
   (let* ((completing-read-fn (if ido-mode
                                  #'ido-completing-read
                                #'completing-read))
-         (execute-file (funcall completing-read-fn
-                                dmenu-prompt-string
-                                (append dmenu--history-list
-                                        dmenu--cache-executable-files)
-                                nil
-                                'confirm
-                                nil))
+         (execute-file (funcall completing-read-fn dmenu-prompt-string
+                                        (append dmenu--history-list
+                                                (cl-remove-if (lambda (x)
+                                                                (member x dmenu--history-list))
+                                                              dmenu--cache-executable-files))
+                                        nil
+                                        'confirm
+                                        nil))
          (args (when (= prefix 4)
                  (split-string-and-unquote (read-string "please input the parameters: ")))))
-    ;; Add history entries when the user input was a PATH command followed by
-    ;; one or more arguments.
-    (if (let ((cmd+args (split-string execute-file)))
-          (and (> (length cmd+args) 1)
-               (member (car cmd+args) dmenu--cache-executable-files)))
-        (push execute-file dmenu--history-list))
-    ;; Now, limit the size/length of history to `dmenu-history-size' entries.
+    (pushnew execute-file dmenu--history-list :test #'string-equal)
     (cond ((< dmenu-history-size 1)
            (setq dmenu--history-list nil))
           ((> (length dmenu--history-list) dmenu-history-size)


### PR DESCRIPTION
This fixes issue #8.

Don't store incomplete command entries -- like "thun" (which, say, completed to the PATH command "thunar") -- in command history (which gets recycled into subsequent read completion candidates), but still preserve the current functionality of the saving/recyling of "custom commands" (i.e., PATH commands with arguments) like "thunar -v".

The issue of saving incomplete commands was caused by the inner workings of the completing read function (and its dependencies) which saves the user input into the value of a symbol suppiled by the calling code (in our case, `dmenu--history-list`).  Not finding a clear way to "tell" the completing read function exactly which user inputs were OK (and which were not OK) to push onto the history symbol's value, the fix here simply takes that responsibility away from the completing read function and we now just manually jigger our own history.